### PR TITLE
Параметризация LocalizableString

### DIFF
--- a/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers.csproj
+++ b/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>Mindbox.I18n.Analyzers</PackageId>
-    <PackageVersion>1.1.2</PackageVersion>
+    <PackageVersion>1.1.3</PackageVersion>
     <Authors>Mindbox</Authors>
     <RepositoryUrl>https://github.com/mindbox-moscow/Mindbox.I18n</RepositoryUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -17,7 +17,7 @@
     <Copyright>Copyright Mindbox 2018</Copyright>
     <PackageTags>Mindbox, I18n, analyzers</PackageTags>
     <NoPackageAnalysis>false</NoPackageAnalysis>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
    
   <ItemGroup>

--- a/Mindbox.I18n/LocalizableString.cs
+++ b/Mindbox.I18n/LocalizableString.cs
@@ -38,6 +38,9 @@ namespace Mindbox.I18n
 
 		public LocalizableString WithContext<TContext>(TContext context) where TContext : class
 		{
+			if (this.context != null)
+				throw new InvalidOperationException($"Context is already set");
+
 			this.context = context ?? throw new ArgumentNullException(nameof(context));
 
 			return this;
@@ -45,6 +48,14 @@ namespace Mindbox.I18n
 
 		public TContext GetContext<TContext>() where TContext : class
 		{
+			if (context == null)
+				return null;
+
+			var result = context as TContext;
+			if (result == null)
+				throw new InvalidOperationException(
+					$"Context is not empty, but can't cast it's value of type {context.GetType()} to {typeof(TContext)}");
+
 			return context as TContext;
 		}
 	}

--- a/Mindbox.I18n/Mindbox.I18n.csproj
+++ b/Mindbox.I18n/Mindbox.I18n.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>Mindbox.I18n</PackageId>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.1.3</PackageVersion>
     <Authors>Mindbox</Authors>
     <RepositoryUrl>https://github.com/mindbox-moscow/Mindbox.I18n</RepositoryUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -17,7 +17,7 @@
     <Copyright>Copyright Mindbox 2018</Copyright>
     <PackageTags>Mindbox, I18n</PackageTags>
     <NoPackageAnalysis>false</NoPackageAnalysis>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Добавил в класс `LocalizableString` два обобщённых метода (`WithContext<T>` и `GetContext<T>`) для того, чтобы иметь возможность накапливать в объекте значения параметров, посредством использования объекта `CompositeTemplateViewModelBuilder` (или в более общем виде `TemplateViewModelBuilder`). Контракт таков, что `WithContext<T>` ожидает ссылку на объект (не `null`), а `GetContext<T>` возвращает ссылку на объект или `null` (в случае, если не была произведена установка контекста ~или что-то пошло не так~).