### PR TITLE
Add en-GB locale

### DIFF
--- a/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers.csproj
+++ b/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.4" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" PrivateAssets="all" />
 
   </ItemGroup>
   <ItemGroup>

--- a/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers.csproj
+++ b/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers/Mindbox.I18n.Analyzers.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" PrivateAssets="all" />
 

--- a/Mindbox.I18n/Locale.cs
+++ b/Mindbox.I18n/Locale.cs
@@ -28,6 +28,7 @@ public static class Locales
 
 	public static ILocale ruRU { get; } = new Locale("ru-RU");
 	public static ILocale enUS { get; } = new Locale("en-US");
+	public static ILocale enGB { get; } = new Locale("en-GB");
 
 	public static ILocale GetByName(string name) => _localesByName[name];
 
@@ -42,7 +43,8 @@ public static class Locales
 		_localesByName = new[]
 		{
 			ruRU,
-			enUS
+			enUS,
+			enGB
 		}.ToDictionary(locale => locale.Name);
 	}
 }

--- a/Mindbox.I18n/Mindbox.I18n.csproj
+++ b/Mindbox.I18n/Mindbox.I18n.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mindbox.I18n.Abstractions\Mindbox.I18n.Abstractions.csproj" />


### PR DESCRIPTION
https://github.com/maestra-io/issues/issues/2

Нужна в DirectCrm для форматирования дат там, где нужен английский язык, но не нужны американские упоротости (даты вида MM/DD/YYYY и AM/PM в часах).

**В переводах использовать не будем.** По крайней мере прямо сейчас.