### PR TITLE
Copy new localizable attribute

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
   <PropertyGroup>
-      <VersionMajor>13</VersionMajor>
+      <VersionMajor>14</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <BuildNumber>$(BuildNumber)</BuildNumber>
       <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>

--- a/Mindbox.I18n.Abstractions/LocalizableEnumMemberAttribute.cs
+++ b/Mindbox.I18n.Abstractions/LocalizableEnumMemberAttribute.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2022 Mindbox Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Mindbox.I18n.Abstractions;
+
+[AttributeUsage(AttributeTargets.Field)]
+public sealed class LocalizableEnumMemberAttribute : Attribute
+{
+	public LocalizableString LocalizableString { get; }
+
+#pragma warning disable CA1019
+	public LocalizableEnumMemberAttribute([LocalizationKey] string localizationKey)
+#pragma warning restore CA1019
+		=> LocalizableString = LocalizableString.ForKey(localizationKey);
+}


### PR DESCRIPTION
Скопировал LocalizableEnumMemberAttribute.cs в Abstractions. Сделал это потому что задачу перевода всех библиотек и репозиториев на один атрибут хочу сделать так:

1. Скопировать LocalizableEnumMemberAttribute.cs в Abstractions
2. Заменить в проектах использование старого атрибута и нового атрибута, но из Templates на атрибут из Abstractions
3. Удалить старый атрибут и новый атрибут в Templates


Мне кажется что при таком алгоритме ничего не сломается и всё будет работать даже тогда, когда процесс миграции атрибута со старого на новый еще не завершен