### PR TITLE
Return localizable display

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <PropertyGroup>
       <VersionMajor>14</VersionMajor>
-      <VersionMinor>0</VersionMinor>
+      <VersionMinor>1</VersionMinor>
       <BuildNumber>$(BuildNumber)</BuildNumber>
       <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>
       <PackageVersion>$(VersionMajor).$(VersionMinor).$(BuildNumber)$(VersionTag)</PackageVersion>

--- a/Mindbox.I18n.Abstractions/LocalizableDisplayAttribute.cs
+++ b/Mindbox.I18n.Abstractions/LocalizableDisplayAttribute.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2022 Mindbox Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Mindbox.I18n.Abstractions;
+
+[AttributeUsage(AttributeTargets.Field)]
+[Obsolete("Use Mindbox.I18n.Abstractions.LocalizableEnumMember instead")]
+public sealed class LocalizableDisplayAttribute : Attribute
+{
+#pragma warning disable CA1019
+	public LocalizableDisplayAttribute([LocalizationKey] string name)
+	{
+		LocalizableName = LocalizableString.ForKey(name);
+	}
+
+	public LocalizableDisplayAttribute([LocalizationKey] string name, [LocalizationKey] string description)
+	{
+		LocalizableName = LocalizableString.ForKey(name);
+		LocalizableDescription = LocalizableString.ForKey(description);
+	}
+#pragma warning restore CA1019
+	public LocalizableString LocalizableName { get; }
+	public LocalizableString? LocalizableDescription { get; }
+}


### PR DESCRIPTION
[Задача FRMWK-682 ](https://tracker.yandex.ru/FRMWK-682)

вернул старый атрибут в библиотеку для того, чтобы минимизировать ошибки в рантайме. После обновления всех пакетов и удаления всех юзаджей удалим и старый атрибут